### PR TITLE
Update MTApp.php

### DIFF
--- a/src/Core/MTApp.php
+++ b/src/Core/MTApp.php
@@ -112,9 +112,16 @@ class MTApp {
   } 
 
   protected static function _redirectInactive() {
-    
+  
     $uri = self::config('redirectInactive');
-    header( 'Location: ' . env('REQUEST_SCHEME') .'://' . self::config('primaryDomain') . $uri );
+
+    if(strpos($uri, 'http') !== false) {
+      $full_uri = $uri;
+    } else {
+      $full_uri = env('REQUEST_SCHEME') .'://' . self::config('primaryDomain') . $uri;
+    }
+  
+    header( 'Location: ' . $full_uri );
     exit;
   
   } 


### PR DESCRIPTION
Enable redirectInactive() to redirect to a completely different site, e.g. where the site uses a separate subdomain on which to run registration. This change maintains the existing functionality but alternatively allows a full URL to be entered in the config param and used raw.