### PR TITLE
Allow qualifier to be modified prior to use

### DIFF
--- a/src/Core/MTApp.php
+++ b/src/Core/MTApp.php
@@ -102,6 +102,17 @@ class MTApp {
     $tbl = TableRegistry::get( $modelConf['className'] );
 
     //blend in config defined conditions
+    if($modelConf['modifyQualifier']) {
+      switch($modelConf['modifyQualifier']['method']) {
+        case 'str_replace':
+          $qualifier = str_replace($modelConf['modifyQualifier']['remove'], '', $qualifier);
+        break;
+
+        default:
+          // nothing
+        break;
+      }
+    }
     $conditions = array_merge([$modelConf['field']=>$qualifier], $modelConf['conditions']);
 
     //Query model and store in cache


### PR DESCRIPTION
The plugin assumes that the qualifier will be stored in the form of subdomain.domain.tld in the tenant table. Some also just store the subdomain (as the domain will change depending on environment, dev, stage, live). This commit adds a config var to model (modifyQualifier) with the key 'method'. The only method supported now is str_replace and another config var model.modifyQualifier.remove gives the pattern which is removed completely.